### PR TITLE
CI/CD Setup and Container Orchestration (Update main)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.git
+.next
+.dockerignore
+Dockerfile

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,75 @@
+name: CI/CD Workflow
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+
+  pull_request:
+    branches:
+      - develop
+
+env:
+  APP_NAME: farm-goods
+
+jobs:
+  # Job 1: develop
+  test_and_build_develop:
+    runs-on: ubuntu-latest
+    # รันเมื่อ push → develop หรือ PR → develop
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/develop') || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'develop') }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Test
+        run: npm test
+
+      - name: Build Docker Image (Develop)
+        run: docker build -t ${{ env.APP_NAME }}:develop .
+
+  # Job 2: main
+  build_and_release_main:
+    runs-on: ubuntu-latest
+    # รันเฉพาะเมื่อ push เข้า main
+    if: ${{ github.ref == 'refs/heads/main' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # สร้างตัวแปร VERSION = v1.<run_number>
+      - name: Set Version
+        id: versioning
+        run: echo "VERSION=v1.${{ github.run_number }}" >> $GITHUB_OUTPUT
+
+      # Build + Push Docker image ด้วย Tag เดียวกับ VERSION
+      - name: Build & Push
+        run: |
+          IMAGE_TAG="${{ steps.versioning.outputs.VERSION }}"
+          IMAGE_NAME="${{ secrets.DOCKER_USERNAME }}/${{ env.APP_NAME }}:${IMAGE_TAG}"
+
+          echo "Docker Image Name: $IMAGE_NAME"
+
+          docker build -t "${IMAGE_NAME}" .
+          docker push "${IMAGE_NAME}"
+
+      # สร้าง Release บน GitHub ด้วย tag เดียวกับ Docker image
+      - name: Create Release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ steps.versioning.outputs.VERSION }}
+          release_name: "Release ${{ steps.versioning.outputs.VERSION }}"
+          draft: false
+          prerelease: false

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,9 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7ea78963-a8ce-4113-93a0-1e27e1cf8aae" name="Changes" comment="" />
+    <list default="true" id="7ea78963-a8ce-4113-93a0-1e27e1cf8aae" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:latest
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm install
+
+COPY .. .
+
+RUN npx prisma generate
+
+RUN npm run build
+
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    depends_on:
+      - postgres
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@postgres:5432/farm-goods
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:latest
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: farm-goods
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    restart: unless-stopped
+
+  pgadmin:
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+    ports:
+      - "8080:80"
+    depends_on:
+      - postgres
+    restart: unless-stopped
+
+volumes:
+  pgdata:


### PR DESCRIPTION
# CI/CD Setup
*(Push from develop into main)*
- เพิ่ม Dockerfile สำหรับ build แอปด้วย Node.js + Prisma
- สร้าง GitHub Actions workflow สำหรับ CI/CD โดยแบ่งออกเป็น 2 Job:
   - Job 1: test_and_build_develop
      - รันเมื่อมี push หรือ PR เข้าสู่ branch develop 
      - รันเทสที่มีทั้งหมด
   - Job 2: build_and_release_main
      - รันเมื่อมี push เข้า branch main 
      - ทำการ build และ push Docker image ขึ้น Docker Hub โดย tag เป็น v1.<run_number>
      - สร้าง GitHub release อัตโนมัติจาก version เดียวกัน
- เพิ่ม .dockerignore เพื่อ exclude ไฟล์/โฟลเดอร์ที่ไม่จำเป็นออกจาก Docker context เช่น node_modules, .git, .next ฯลฯ

# Container Orchestration
*(Push from develop into main)*
- สร้าง docker-compose.yml โดยมีการเรียกใช้ Service ดังนี้
   - app: รันแอปพลิเคชันหลัก โดย build จาก Dockerfile สามารถเข้าผ่าน port 3000
   - postgres: ใช้ image postgres:latest สำหรับจัดการฐานข้อมูล PostgreSQL
   - pgadmin: ใช้ image dpage/pgadmin4 สำหรับเข้าถึงฐานข้อมูลผ่าน UI โดยสามารถเข้าผ่าน port 8080
   - กำหนด volume ชื่อ pgdata สำหรับเก็บข้อมูลถาวรของ Postgres
   
----------------------------
*(หมายเหตุ: Push ไปยัง main หลังจากทำ S2 เนื่องจากระหว่างทำ ทำในช่วงเวลาที่สมาชิกในทีมไม่สะดวกมากด Approve ได้)*